### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/reverse_rdp.yml
+++ b/.github/workflows/reverse_rdp.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds support for triggering the workflow manually, using the [`workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) trigger.

![Screen Shot 2021-02-27 at 10 02 25 PM](https://user-images.githubusercontent.com/36649395/109409430-7fe0a600-7947-11eb-8d4e-642745fe8de3.png)
